### PR TITLE
Add default biname to waka-box workflow

### DIFF
--- a/.github/workflows/waka-box.yml
+++ b/.github/workflows/waka-box.yml
@@ -1,4 +1,5 @@
-name: Sync Gist to README
+Just defaults:
+  biname: Sync Gist to README
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Yes def be able to you iiiiiiiu

## 由 Sourcery 提供的摘要

构建：
- 更新 waka-box GitHub Actions workflow 的 YAML，将默认的 `biname` 定义为 "Sync Gist to README"。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update the waka-box GitHub Actions workflow YAML to define a default `biname` of "Sync Gist to README".

</details>